### PR TITLE
20220712: #53 #54 #55

### DIFF
--- a/jhyun/[BOJ]Nqueen.py
+++ b/jhyun/[BOJ]Nqueen.py
@@ -1,0 +1,27 @@
+def backTracking(rowPos):
+    global answer
+
+    # 퀸을 모두 배치했다면 끝
+    if rowPos == n:
+        answer += 1
+        return
+
+    for col in range(n):
+        flag = True
+        # 이전 행들에 대해서
+        for row in range(rowPos):
+            # 같은 열에 위치해있거나 대각선에 퀸이 이미 존재한다면 가지치기
+            if queenLocation[row] == col or rowPos - row == abs(col - queenLocation[row]):
+                flag = False
+                break
+        if flag:
+            queenLocation[rowPos] = col
+            backTracking(rowPos + 1)
+
+
+n = int(input())
+answer = 0
+# 각 row마다 queen이 위치하는 인덱스를 저장하는 리스트
+queenLocation = [0] * n
+backTracking(0)
+print(answer)

--- a/jhyun/[BOJ]바이러스.py
+++ b/jhyun/[BOJ]바이러스.py
@@ -1,0 +1,23 @@
+from collections import deque
+N = int(input())
+edge = int(input())
+graph = [[] for _ in range(N + 1)]
+for _ in range(edge):
+    s, e = map(int, input().split())
+    graph[s].append(e)
+    graph[e].append(s)
+def bfs(start: int):
+    q = deque([start])
+    visit = [False] * (N + 1)
+    visit[start] = True
+    result = 0
+    while q:
+        cur = q.popleft()
+        for nxt in graph[cur]:
+            if not visit[nxt]:
+                visit[nxt] = True
+                result += 1
+                q.append(nxt)
+    return result
+answer = bfs(1)
+print(answer)

--- a/jhyun/[BOJ]줄세우기.py
+++ b/jhyun/[BOJ]줄세우기.py
@@ -1,0 +1,21 @@
+from collections import deque
+N, M = map(int, input().split())
+indegree = [0] * (N + 1)
+graph = [[] for _ in range(N + 1)]
+for _ in range(M):
+    s, e = map(int, input().split())
+    indegree[e] += 1
+    graph[s].append(e)
+def topology_sort():
+    q = deque([])
+    for i in range(1, N + 1):
+        if indegree[i] == 0:
+            q.append(i)
+    while q:
+        cur = q.popleft()
+        print(cur, end=' ')
+        for nxt in graph[cur]:
+            indegree[nxt] -= 1
+            if indegree[nxt] == 0:
+                q.append(nxt)
+topology_sort()

--- a/jhyun/[LET]Trapping Rain Water.py
+++ b/jhyun/[LET]Trapping Rain Water.py
@@ -1,0 +1,21 @@
+class Solution:
+    def trap(self, height: List[int]) -> int:
+        height.insert(0, 0)
+        height.append(0)
+        n = len(height)
+        left_h = [0] * n
+        right_h = [0] * n
+        max_v, answer = 0, 0
+        for i in range(n):
+            left_h[i] = max_v
+            max_v = max(height[i], max_v)
+        max_v = 0
+        for i in range(n - 1, -1, -1):
+            right_h[i] = max_v
+            max_v = max(height[i], max_v)
+        for i in range(1, n - 1):
+            value = min(left_h[i], right_h[i]) - height[i]
+            if value < 0:
+                value = 0
+            answer += value
+        return answer


### PR DESCRIPTION
#53 
컴퓨터간의 연결관계를 그래프 형태로 나타낼 수 있으며, 감염 컴퓨터 대수를 세는 과정이 BFS와 유사하기 때문에 해당 탐색 방법으로 새로운 컴퓨터를 감염시킬 때마다 +1씩 증가하여 답을 구할 수 있음
#54 
의존적인 관계의 데이터를 순서대로 정렬하는 문제로 위상정렬을 적용해볼 수 있음. 다른 노드에서 들어오는 간선의 개수를 저장하기 위해 indegree 배열을 선언함. 

탐색과정: indegree 값이 0인 것부터 큐에 넣고 다음 노드를 방문할 때마다 -1씩 감소시키면서 처음부터 반복
#55 
i번째 격자에 채워지는 물높이는 min(왼쪽 기둥들의 최대높이, 오른쪽 기둥들의 최대높이) - i번째 기둥 높이 임을 알 수 있음
단순하게 생각하면, i번째 격자에 채워지는 물을 구하기 위해 왼쪽, 오른쪽 최대 높이를 구하기 위해 n번 반복할 수 있지만 n이 2만이기 때문에 시간초과가 발생할 수 있음.
조금 생각해보면, 왼쪽 높이값이 오른쪽에도 적용됨을 알 수 있음. 반대도 마찬가지
즉, 왼쪽 -> 오른쪽, 오른쪽 -> 왼쪽 방향으로 탐색하면서 최대 높이를 배열에 저장해두고 i번째 격자에 채워지는 물을 구하기 위해 사용할 수 있음 (O(N))